### PR TITLE
Removed duplicated dependancies

### DIFF
--- a/timestamp_tools/package.xml
+++ b/timestamp_tools/package.xml
@@ -20,7 +20,4 @@
 
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
-
-  <test_depend>roslib</test_depend>
-  <test_depend>roscpp</test_depend>
 </package>


### PR DESCRIPTION
test_depend tags should only include additional dependencies required for testing. 
