### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/driver_base/package.xml
+++ b/driver_base/package.xml
@@ -29,4 +29,8 @@
   <run_depend>diagnostic_updater</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/timestamp_tools/package.xml
+++ b/timestamp_tools/package.xml
@@ -20,4 +20,8 @@
 
   <run_depend>roslib</run_depend>
   <run_depend>roscpp</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
These packages don't have any binaries in them, so they can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
